### PR TITLE
Changing GridDistance from 5 to 1.5

### DIFF
--- a/system.json
+++ b/system.json
@@ -53,7 +53,7 @@
     "minimum": "10",
     "verified": "11"
   },
-  "gridDistance": 5,
+  "gridDistance": 1.5,
   "gridUnits": "m",
   "primaryTokenAttribute": "blessure",
   "url": "https://github.com/Zakarik/foundry-mm3",


### PR DESCRIPTION
Changing GridDistance to every square has 1.5 instead of 5 meters.

Actual:
![image](https://github.com/Zakarik/foundry-mm3/assets/19476398/19222d1d-42c5-4098-9620-d7e15035e9e6)
