### PR TITLE
Feat: Diagonal movement options to grid

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -259,7 +259,14 @@
       "MeasureSystem":"Measuring system",
       "MeasureSystemHint":"Choose between the metric or imperial system.",
       "Metric":"Metric",
-      "Imperial":"Imperial"
+      "Imperial":"Imperial",
+      "DiagonalMovement":{
+        "Name": "Diagonal Movement",
+        "Hint": "Configures which diagonal movement rule will be used in the system.",
+        "Manhattan": "Manhattan (3m)",
+        "Equidistant": "Equidistant (1.5m)",
+        "Pathfinder": "Pathfinder/3.5 (1.5m/3m/1.5m)"
+      }
     },
     "ROLL":{
       "AttSuccess":"The attack hits !",

--- a/lang/es.json
+++ b/lang/es.json
@@ -259,7 +259,14 @@
       "MeasureSystem":"Sistema de medición",
       "MeasureSystemHint":"Elige entre el sistema métrico o imperial.",
       "Metric":"Métrico",
-      "Imperial":"Imperial"
+      "Imperial":"Imperial",
+      "DiagonalMovement":{
+        "Name": "Movimiento Diagonal",
+        "Hint": "Configura qué regla de movimiento diagonal se usará en el sistema.",
+        "Manhattan": "Manhattan (3m)",
+        "Equidistant": "Equidistante (1.5m)",
+        "Pathfinder": "Pathfinder/3.5 (1.5m/3m/1.5m)"
+      }
     },
     "ROLL":{
       "AttSuccess":"El ataque golpea !",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -259,7 +259,14 @@
       "MeasureSystem":"Système de mesure",
       "MeasureSystemHint":"Choisir entre le système métrique ou impérial.",
       "Metric":"Métrique",
-      "Imperial":"Imperial"
+      "Imperial":"Imperial",
+      "DiagonalMovement":{
+        "Name": "Mouvement Diagonal",
+        "Hint": "Configurez quelle règle de mouvement diagonal sera utilisée dans le système.",
+        "Manhattan": "Manhattan (3m)",
+        "Equidistant": "Équidistant (1.5m)",
+        "Pathfinder": "Pathfinder/3.5 (1.5m/3m/1.5m)"
+      }
     },
     "ROLL":{
       "AttSuccess":"L'Attaque touche !",

--- a/lang/it.json
+++ b/lang/it.json
@@ -259,7 +259,14 @@
       "MeasureSystem":"Sistema di misurazione",
       "MeasureSystemHint":"Scegli tra il sistema metrico o imperiale.",
       "Metric":"Metrico",
-      "Imperial":"Imperiale"
+      "Imperial":"Imperiale",
+      "DiagonalMovement":{
+        "Name": "Movimento Diagonale",
+        "Hint": "Configura quale regola di movimento diagonale verrà utilizzata nel sistema.",
+        "Manhattan": "Manhattan (3m)",
+        "Equidistant": "Equidistante (1.5m)",
+        "Pathfinder": "Pathfinder/3.5 (1.5m/3m/1.5m)"
+      }
     },
     "ROLL":{
       "AttSuccess":"L'attacco colpisce !",

--- a/lang/ptbr.json
+++ b/lang/ptbr.json
@@ -259,7 +259,14 @@
       "MeasureSystem":"Sistema de medição",
       "MeasureSystemHint":"Escolha entre o sistema métrico ou imperial.",
       "Metric":"Métrico",
-      "Imperial":"Imperial"
+      "Imperial":"Imperial",
+      "DiagonalMovement":{
+        "Name": "Movimento diagonal",
+        "Hint": "Configura qual regra de movimento diagonal será usada no sistema.",
+        "Manhattan": "Manhattan (3m)",
+        "Equidistant": "Equidistante (1.5m)",
+        "Pathfinder": "Pathfinder/3.5 (1.5m/3m/1.5m)"
+      }
     },
     "ROLL":{
       "AttSuccess":"O ataque acerta !",

--- a/module/helpers/canvas.mjs
+++ b/module/helpers/canvas.mjs
@@ -1,0 +1,36 @@
+/** @override */
+export const measureDistances = function (segments, options = {}) {
+    if (!options.gridSpaces) return BaseGrid.prototype.measureDistances.call(this, segments, options);
+  
+    // Track the total number of diagonals
+    let nDiagonal = 0;
+    const rule = this.parent.diagonalRule;
+    const d = canvas.dimensions;
+  
+    // Iterate over measured segments
+    return segments.map(s => {
+      let r = s.ray;
+      nDiagonal = 0;
+  
+      // Determine the total distance traveled
+      let nx = Math.abs(Math.ceil(r.dx / d.size));
+      let ny = Math.abs(Math.ceil(r.dy / d.size));
+  
+      // Determine the number of straight and diagonal moves
+      let nd = Math.min(nx, ny);
+      let ns = Math.abs(ny - nx);
+      nDiagonal += nd;
+  
+      if (rule == "PATHFINDER") {
+        let nd10 = Math.floor(nDiagonal / 2) - Math.floor((nDiagonal - nd) / 2);
+        let spaces = (nd10 * 2) + (nd - nd10) + ns;
+        return spaces * canvas.dimensions.distance;
+      } else if (rule == "EQUIDISTANT") {
+        return (ns + nd) * canvas.scene.data.gridDistance;
+      }
+  
+      // Standard Manhattan Movement
+      return (ns + nd + nDiagonal) * canvas.scene.data.gridDistance;
+    });
+  };
+  

--- a/module/mm.mjs
+++ b/module/mm.mjs
@@ -17,6 +17,7 @@ import { RegisterSettings } from "./settings.mjs";
 import { preloadHandlebarsTemplates } from "./helpers/templates.mjs";
 import { MM3 } from "./helpers/config.mjs";
 import toggler from './helpers/toggler.js';
+import { measureDistances } from "./helpers/canvas.mjs";
 
 import {
   rollAtkTgt,
@@ -813,4 +814,9 @@ Hooks.on('renderTokenHUD', (hud, html, actor) => {
   if(actor.bar2.attribute === 'blessure') toUpdate = 'bar2';
 
   if(toUpdate !== undefined) html.find(`input[name="${toUpdate}.value"]`).prop("type", "number");
+});
+
+Hooks.on("canvasInit", function () {
+  canvas.grid.diagonalRule = game.settings.get("mutants-and-masterminds-3e", "diagonalMovement");
+  SquareGrid.prototype.measureDistances = measureDistances;
 });

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -130,4 +130,19 @@ export const RegisterSettings = function () {
             foundry.utils.debouncedReload();
         }
     });
+
+    game.settings.register("mutants-and-masterminds-3e", "diagonalMovement", {
+        name: "MM3.SETTING.DiagonalMovement.Name",
+        hint: "MM3.SETTING.DiagonalMovement.Hint",
+        scope: "world",
+        config: true,
+        default: "EQUIDISTANT",
+        type: String,
+        choices: {
+            "MANHATTAN": "MM3.SETTING.DiagonalMovement.Manhattan",
+            "EQUIDISTANT": "MM3.SETTING.DiagonalMovement.Equidistant",
+            "PATHFINDER": "MM3.SETTING.DiagonalMovement.Pathfinder",
+        },
+        onChange: value => canvas.grid.diagonalRule = value
+    });
 };


### PR DESCRIPTION
# Diagonal Movement
Feature to configure diagonal movement in system settings. Before there is only one, Equidistant (1.5m). This feature adds two new options, Manhattan (3m) and Pathfinder/D&D (1.5m/3m/1.5m).

![image](https://github.com/Zakarik/foundry-mm3/assets/19476398/ddbd7108-1273-4217-98c1-3cc6b29d6db3)

![image](https://github.com/Zakarik/foundry-mm3/assets/19476398/afa86640-cd5b-47c4-96b0-b8397f4e40b9)

![image](https://github.com/Zakarik/foundry-mm3/assets/19476398/0343a69e-0b86-4b20-a93b-98540d1047a8)

Translations it's also added to all supported idioms.