### PR TITLE
fix: prevent atk preparation throwing error

### DIFF
--- a/module/documents/models/personnage-data-model.mjs
+++ b/module/documents/models/personnage-data-model.mjs
@@ -874,7 +874,7 @@ export class PersonnageDataModel extends foundry.abstract.TypeDataModel {
                     let rang = Number(dataPwr?.system?.cout?.rang ?? 1)
                     let modEff = Number(atkData?.mod?.eff ?? 0);
 
-                    if(dataPwr.system.special === 'dynamique') rang = this.pwr?.[pwr]?.cout?.rang ?? 0;
+                    if(dataPwr?.system.special === 'dynamique') rang = this.pwr?.[pwr]?.cout?.rang ?? 0;
 
                     effet += rang+modEff;
                 }


### PR DESCRIPTION
This prevents the overall actor preparation from throwing an error when an attack is encountered that was associated with a power that can no longer be found.